### PR TITLE
Customer product code

### DIFF
--- a/source/includes/api/curl_snippets/post_order_request.md
+++ b/source/includes/api/curl_snippets/post_order_request.md
@@ -50,6 +50,7 @@ curl -X "POST" "http://api.mwwondemand.com/api/orders" \
         "quantity": 2,
         "description": "It\'s not sò fluffy!",
         "product-code": "PRT-GEN-ZOH99",
+        "customer-product-code": "YOUR_UPC/SKU_NUMBER",
         "item-properties": {
           "thread-color": "white"
         },
@@ -67,6 +68,7 @@ curl -X "POST" "http://api.mwwondemand.com/api/orders" \
         "quantity": 5,
         "description": "Velour Vest",
         "product-code": "PRT-GEN-XOH99",
+        "customer-product-code": "YOUR_UPC/SKU_NUMBER",
         "item-properties": {
           "thread-color": "white"
         },

--- a/source/includes/api/orders.md.erb
+++ b/source/includes/api/orders.md.erb
@@ -37,8 +37,9 @@ type <br><em>string</em> | Resource the object represents This should always be 
 attributes <br><em>object</em> | The object that contains all the pertanent information about the line-item resource.
 line-number <br><em>number</em> | Each line should have a line number in incrementing order. If omitted a line number will be automatically assigned.
 quantity <br><em>number</em> | The number of items you want to order for a given product.
-description <br><em>string</em> | You description of the item. If omitted the default product description will be used.
-product-code <br><em>string</em> | The product code of the item to order.
+description <br><em>string</em> | Your description of the item. If omitted the default product description will be used.
+product-code <br><em>string</em> | The MWW product code of the item to order.
+customer-product-code <br><em>string (optional)</em> | Your custom SKU or UPC number.
 item-properties <br><em>object (optional)</em> | Additional attributes for some products. This can be omitted in most cases. See products for more information.
 designs <br><em>array[objects]</em> | An array of objects describing information about the artwork to be printed.
 image-remote-url <br><em>string</em> | A publically accessible path to the source artwork.


### PR DESCRIPTION
Add description of `customer-product-code` line item attribute and cURL example. Other examples will be added as part of overhaul of example code.