### PR TITLE
Re-enabled test orders

### DIFF
--- a/source/includes/api/curl_snippets/post_order_request.md
+++ b/source/includes/api/curl_snippets/post_order_request.md
@@ -10,6 +10,7 @@ curl -X "POST" "http://api.mwwondemand.com/api/orders" \
       "vendor-po": "1467988109",
       "shipping-method": "SAMPLE",
       "shipping-account-number": "1234",
+      "order-type": "test"
     }
   },
   "included": [

--- a/source/includes/api/curl_snippets/post_order_request.md
+++ b/source/includes/api/curl_snippets/post_order_request.md
@@ -10,7 +10,7 @@ curl -X "POST" "http://api.mwwondemand.com/api/orders" \
       "vendor-po": "1467988109",
       "shipping-method": "SAMPLE",
       "shipping-account-number": "1234",
-      "order-type": "test"
+      "test-order": "test"
     }
   },
   "included": [

--- a/source/includes/api/java_snippets/post_order_request.md
+++ b/source/includes/api/java_snippets/post_order_request.md
@@ -40,6 +40,7 @@ public class post_request
               "'vendor-po': '146798810923'," +
               "'shipping-method': 'SAMPLE'," +
               "'shipping-account-number': '1234'," +
+              "'order-type': 'test'" +
             "}" +
           "}," +
           "'included': [" +

--- a/source/includes/api/java_snippets/post_order_request.md
+++ b/source/includes/api/java_snippets/post_order_request.md
@@ -40,7 +40,7 @@ public class post_request
               "'vendor-po': '146798810923'," +
               "'shipping-method': 'SAMPLE'," +
               "'shipping-account-number': '1234'," +
-              "'order-type': 'test'" +
+              "'test-order': 'test'" +
             "}" +
           "}," +
           "'included': [" +

--- a/source/includes/api/orders.md.erb
+++ b/source/includes/api/orders.md.erb
@@ -36,7 +36,7 @@ vendor-po <br><em>string / number</em> | Your PO number. This string/number must
 shipping-method <br><em>string</em> | The shipping carrier and method for the order. For example, use USPSF for USPS First Class. See shipping methods.
 shipping-account-number <br><em>string</em> | The shipping account number associated with the shipping carrier and order.
 included <br><em>array[objects]</em> | The array element describing the item(s) to be included in the order.
-order-type <br> <em> string </em> <br> optional | Optional field, 'test' for a test order, 'new' for a new regular order (defaults to 'new') 
+test-order <br> <em> string </em> <br> optional | Optional field, 'test' for a test order, 'new' for a new regular order (defaults to 'new') 
 
 
 *Line Item details*

--- a/source/includes/api/orders.md.erb
+++ b/source/includes/api/orders.md.erb
@@ -36,7 +36,7 @@ vendor-po <br><em>string / number</em> | Your PO number. This string/number must
 shipping-method <br><em>string</em> | The shipping carrier and method for the order. For example, use USPSF for USPS First Class. See shipping methods.
 shipping-account-number <br><em>string</em> | The shipping account number associated with the shipping carrier and order.
 included <br><em>array[objects]</em> | The array element describing the item(s) to be included in the order.
-<%# order-type <br> <em> string </em> <br> optional | Optional field, 'test' for a test order, 'new' for a new regular order (defaults to 'new') %>
+order-type <br> <em> string </em> <br> optional | Optional field, 'test' for a test order, 'new' for a new regular order (defaults to 'new') 
 
 
 *Line Item details*

--- a/source/includes/api/php_snippets/post_order_request.md
+++ b/source/includes/api/php_snippets/post_order_request.md
@@ -27,6 +27,7 @@ $body = '"data": {
      "vendor-po": "1467988109",
      "shipping-method": "SAMPLE",
      "shipping-account-number": "1234",
+     "order-type": "test"
    }
  },
  "included": [

--- a/source/includes/api/php_snippets/post_order_request.md
+++ b/source/includes/api/php_snippets/post_order_request.md
@@ -27,7 +27,7 @@ $body = '"data": {
      "vendor-po": "1467988109",
      "shipping-method": "SAMPLE",
      "shipping-account-number": "1234",
-     "order-type": "test"
+     "test-order": "test"
    }
  },
  "included": [

--- a/source/includes/api/python_snippets.md/post_order_request.md
+++ b/source/includes/api/python_snippets.md/post_order_request.md
@@ -25,7 +25,7 @@ def send_request():
               "vendor-po": "14679881092",
               "shipping-method": "SAMPLE",
               "shipping-account-number": "1234",
-              "order-type": "test"
+              "test-order": "test"
             }
           },
           "included": [

--- a/source/includes/api/python_snippets.md/post_order_request.md
+++ b/source/includes/api/python_snippets.md/post_order_request.md
@@ -24,7 +24,8 @@ def send_request():
             "attributes": {
               "vendor-po": "14679881092",
               "shipping-method": "SAMPLE",
-              "shipping-account-number": "1234"
+              "shipping-account-number": "1234",
+              "order-type": "test"
             }
           },
           "included": [

--- a/source/includes/api/ruby_snippets/post_order_request.md
+++ b/source/includes/api/ruby_snippets/post_order_request.md
@@ -25,7 +25,7 @@ def send_request
        "vendor-po": "14679881309",
        "shipping-method": "SAMPLE",
        "shipping-account-number": "1234",
-       "order-type": "test"
+       "test-order": "test"
      }
    },
    "included": [

--- a/source/includes/api/ruby_snippets/post_order_request.md
+++ b/source/includes/api/ruby_snippets/post_order_request.md
@@ -24,7 +24,8 @@ def send_request
      "attributes": {
        "vendor-po": "14679881309",
        "shipping-method": "SAMPLE",
-       "shipping-account-number": "1234"
+       "shipping-account-number": "1234",
+       "order-type": "test"
      }
    },
    "included": [


### PR DESCRIPTION
Test order documentation was commented out in last pull request because it was not implemented, here it is again.